### PR TITLE
Attach tailscale to app container network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2024-04-21
+### Added
+- `tailscale_attach`
+
 ### Changed
+- Add ts container to app container network, not the other way around
+- Rename `tailscale_down` to `tailscale_detach`
+- Data storage goes in a plugin data dir, not the storage dir
+- Print tailscale serve url first
+
+### Fixed
+- `tailscale_serve_url` does not request TTY during exec
 
 ## [0.0.4] - 2024-04-19
 ### Changed
@@ -39,7 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `tailscale_serve_stop` function
 - `post-destroy` trigger
 
-[unreleased]: https://github.com/andrew-womeldorf/dokku-tailscale/compare/0.0.4...HEAD
+[unreleased]: https://github.com/andrew-womeldorf/dokku-tailscale/compare/0.1.0...HEAD
+[0.1.0]: https://github.com/andrew-womeldorf/dokku-tailscale/compare/0.0.4...0.1.0
 [0.0.4]: https://github.com/andrew-womeldorf/dokku-tailscale/compare/0.0.3...0.0.4
 [0.0.3]: https://github.com/andrew-womeldorf/dokku-tailscale/compare/0.0.2...0.0.3
 [0.0.2]: https://github.com/andrew-womeldorf/dokku-tailscale/compare/0.0.1...0.0.2

--- a/functions
+++ b/functions
@@ -12,32 +12,75 @@ tailscale_up() {
   [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
   verify_app_name "$APP"
 
-  [[ -n "$(tailscale_is_running_for_app)" ]] && dokku_log_info1 "tailscale is running for $APP" && return
+  local authkey="$(config_get --global TS_AUTHKEY)"
+  [[ -z "$authkey" ]] && dokku_log_fail "Set the TS_AUTHKEY with dokku config:set --global"
+
+  # Tailscale will join the app container's network, and will advertise its
+  # name to the tailnet as the hostname of the app container. By default, the
+  # hostname is the container ID. Set the hostname, instead, to the name of the
+  # app, so that the machine in the tailnet is the same name as the app.
+  #
+  # Note that, if the app container is already running when tailscale:up is
+  # called, then the containers need to be restarted in order to take on the
+  # correct hostname. The container will still be put on the tailnet without a
+  # restart, but with the wrong hostname.
+  dokku_log_info1 "settings docker-option for ${APP} to --hostname=${APP}"
+  phases="$(get_phases 'deploy')"
+  add_passed_docker_option phases[@] "--hostname ${APP}"
+
+  # create state dir
+  local storage_directory="${DOKKU_LIB_ROOT}/data/tailscale/${APP}"
+  dokku_log_info1 "Ensuring ${storage_directory} exists"
+  mkdir -p "${storage_directory}"
+
+  touch "${storage_directory}/DOKKU_ENABLED"
+}
+
+tailscale_detach() {
+  [[ -z "$APP" ]] && dokku_log_fail "No app specified"
+  verify_app_name "$APP"
+
+  ( ! tailscale_is_enabled ) && return
+
+  container_id=$("$DOCKER_BIN" ps -qaf "name=ts-$APP")
+  if [[ -n "$container_id" ]] ; then
+    dokku_log_info1 "removing tailscale container ts-${APP}"
+    "$DOCKER_BIN" container stop "${container_id}"
+    "$DOCKER_BIN" container rm "${container_id}"
+  fi
+}
+
+tailscale_down() {
+  [[ -z "$APP" ]] && dokku_log_fail "No app specified"
+  verify_app_name "$APP"
+
+  ( ! tailscale_is_enabled ) && return
+  tailscale_detach
+  rm -f "${DOKKU_LIB_ROOT}/data/tailscale/${APP}/DOKKU_ENABLED"
+}
+
+tailscale_is_enabled() {
+  [[ -z "$APP" ]] && dokku_log_fail "No app specified"
+  verify_app_name "$APP"
+  [[ -f "${DOKKU_LIB_ROOT}/data/tailscale/${APP}/DOKKU_ENABLED" ]]
+}
+
+tailscale_attach() {
+  [[ -z "$APP" ]] && dokku_log_fail "No app specified"
+  verify_app_name "$APP"
+
+  ( ! tailscale_is_enabled ) && return
 
   local authkey="$(config_get --global TS_AUTHKEY)"
   [[ -z "$authkey" ]] && dokku_log_fail "Set the TS_AUTHKEY with dokku config:set --global"
 
-  # create state dir
-  local storage_directory="${DOKKU_LIB_ROOT}/data/storage/ts_${APP}"
-  dokku_log_info1 "Ensuring ${storage_directory} exists"
-  mkdir -p "${storage_directory}"
+  local storage_directory="${DOKKU_LIB_ROOT}/data/tailscale/${APP}"
 
-  # create network
-  dokku_log_info1 "creating network ${APP}"
-  "$DOCKER_BIN" network create "${APP}"
-
-  # set the app container's network mode to share the space with tailscale
-  dokku_log_info1 "settings docker-option for ${APP} to --network=container:ts-${APP}"
-  phases="$(get_phases 'deploy')"
-  add_passed_docker_option phases[@] "--network container:ts-${APP}"
-
-  # start tailscale
   dokku_log_info1 "starting tailscale container ts-${APP}"
   "$DOCKER_BIN" container run \
     "--label=com.dokku.app-name=${APP}" \
     $DOKKU_GLOBAL_RUN_ARGS \
     --name "ts-${APP}" \
-    --hostname "${APP}" \
     --env TS_AUTHKEY="${authkey}" \
     --env TS_EXTRA_ARGS="--advertise-tags=tag:dokku" \
     --env TS_STATE_DIR=/var/lib/tailscale \
@@ -46,33 +89,18 @@ tailscale_up() {
     --cap-add=NET_ADMIN \
     --cap-add=SYS_MODULE \
     --restart unless-stopped \
-    --network "${APP}" \
+    --network "container:${APP}.web.1" \
     --detach \
     tailscale/tailscale:latest
-}
-
-tailscale_down() {
-  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
-  verify_app_name "$APP"
-
-  # remove docker network
-  dokku_log_info1 "removing network ${APP}"
-  "$DOCKER_BIN" network rm "${APP}" || true
-
-  # does not remove the state directory.
-  # unfortunately, tailscale runs as root in its containers, and the ownership
-  # of files and directories in the state dir end up as root, and the dokku
-  # user can't remove them.
-  # would love if there was a better solution for this, but, it shouldn't
-  # really matter, as far as I understand the tailscale state, if it gets
-  # reused...
 }
 
 tailscale_serve_start() {
   [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
   verify_app_name "$APP"
 
-  "$DOCKER_BIN" exec -it "ts-${APP}" tailscale serve --bg "$PORT"
+  ( ! tailscale_is_enabled ) && dokku_log_fail "tailscale is not enabled for $APP"
+
+  "$DOCKER_BIN" exec "ts-${APP}" tailscale serve --bg "$PORT"
   dokku_log_info1 "started serving traffic for ${APP} :${PORT} -> :443"
 }
 
@@ -80,7 +108,9 @@ tailscale_serve_stop() {
   [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
   verify_app_name "$APP"
 
-  "$DOCKER_BIN" exec -it "ts-${APP}" tailscale serve --https=443 off
+  ( ! tailscale_is_enabled ) && dokku_log_fail "tailscale is not enabled for $APP"
+
+  "$DOCKER_BIN" exec "ts-${APP}" tailscale serve --https=443 off
   dokku_log_info1 "stopped serving traffic for ${APP} on :443"
 }
 
@@ -100,7 +130,9 @@ tailscale_serve_url() {
   [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
   verify_app_name "$APP"
 
-  output=$("$DOCKER_BIN" exec -it "ts-${APP}" tailscale serve status)
+  ( ! tailscale_is_enabled ) && return
+
+  output=$("$DOCKER_BIN" exec "ts-${APP}" tailscale serve status)
   if [[ "$(echo $output | tr -d '[:space:]')" != "Noserveconfig" ]]; then
     echo $output | head -n 1 | cut -d ' ' -f 1 | tr -d '[:space:]'
   fi

--- a/install
+++ b/install
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+mkdir -p "${DOKKU_LIB_ROOT}/data/tailscale"

--- a/post-deploy
+++ b/post-deploy
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/tailscale/functions"
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+APP="$1"; INTERNAL_PORT="$2"; INTERNAL_IP_ADDRESS="$3"; IMAGE_TAG="$4";
+
+if tailscale_is_enabled ; then
+    tailscale_detach
+    tailscale_attach
+fi
+

--- a/subcommands/test
+++ b/subcommands/test
@@ -7,8 +7,9 @@ source "$PLUGIN_AVAILABLE_PATH/tailscale/functions"
 cmd-tailscale-test() {
   declare cmd="tailscale:test"
   [[ "$1" == "$cmd" ]] && shift 1
+  declare APP="$1"
 
-  tailscale_test
+  tailscale_detach
 }
 
 cmd-tailscale-test "$@"


### PR DESCRIPTION
Rather than attaching app containers to the tailscale container's network, attach the tailscale container to the app container network.

Originally, a tailscale container would be created, and app containers would set their network mode to share the tailscale container's network space. This caused an issue where, if there was more than one container requesting the same port, the newer container(s) would fail because the port is already taken.

One option could have been to expect the app container to have a dynamic port, whether it sets that port itself or requests tailscale to set the port for the app. But that gets to be too non-deterministic, and sets a higher expectation for an app to be written to comply with this tailscale plugin.

Alternatively, I learned that the tailscale/docker integration will work by swapping which container connects to which network. In this case, which is what is implemented in this PR, the app container starts, and then the tailscale container starts and sets its network mode to share the app container's network. This allows for there to be multiple app containers using the same port assignments, because they're each running in their own network space. This is a more determinstic, and normal, mode to run in.

The tailscale container operates the same way that it used to without issue with one exception. In the old way, the tailscale container sets its hostname with the `--hostname` flag to `docker run...`. The `--hostname` flag is not accepted by docker when paired with this new network mode for a container. However, we can set the `--hostname` flag on the app container, and tailscale will set the machine's name on the tailnet to the value set there, which is what we want. Multiple containers can apparently have the same hostname, so scaling is not a concern with this.

One thing of note is that `tailscale:up` will add the `docker-option` to set the hostname on the app container, which means if the app had already been deployed prior to running `tailscale:up`, then the hostname will be the container ID by default. The containers must be re.......started?deployed? in order to take on the new hostname.