### PR TITLE
Add `TS_ACCEPT_DNS` option, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ Set an auth key or oauth client key to the global config:
 
 ```sh
 dokku config:set --global TS_AUTHKEY=tskey-client-00000000000000000-000000000000000000000000000000000
+
+# Optionally set TS_ACCEPT_DNS either globally or per-app to enable Magic DNS
+# However, this does NOT update /etc/resolv.conf to use 100.100.100.100 in the app container.
+# Use something like `dokku docker-options:add app-name deploy,run --dns=100.100.100.100` to set the DNS
+dokku config:set my-app TS_ACCEPT_DNS=1
 ```
 
 Presently, all apps will be tagged in the tailnet with `dokku`.

--- a/functions
+++ b/functions
@@ -74,6 +74,8 @@ tailscale_attach() {
   local authkey="$(config_get --global TS_AUTHKEY)"
   [[ -z "$authkey" ]] && dokku_log_fail "Set the TS_AUTHKEY with dokku config:set --global"
 
+  local accept_dns="$(config_get --global TS_ACCEPT_DNS || config_get "$APP" TS_ACCEPT_DNS)"
+
   local storage_directory="${DOKKU_LIB_ROOT}/data/tailscale/${APP}"
 
   dokku_log_info1 "starting tailscale container ts-${APP}"
@@ -84,6 +86,7 @@ tailscale_attach() {
     --env TS_AUTHKEY="${authkey}" \
     --env TS_EXTRA_ARGS="--advertise-tags=tag:dokku" \
     --env TS_STATE_DIR=/var/lib/tailscale \
+    ${accept_dns:+--env TS_ACCEPT_DNS=1} \
     --volume "${storage_directory}":/var/lib/tailscale \
     --volume /dev/net/tun:/dev/net/tun \
     --cap-add=NET_ADMIN \

--- a/plugin.toml
+++ b/plugin.toml
@@ -1,4 +1,4 @@
 [plugin]
 description = "dokku tailscale plugin"
-version = "0.1.1"
+version = "0.1.2"
 [plugin.config]


### PR DESCRIPTION
Adds an option to enable magic DNS so that apps can access other apps in the tailnet. I'm sure it's possible, but I also don't know how to set `dokku docker-options:add app-name deploy,run --dns=100.100.100.100`` from these scripts. Right now I'm just running it by hand on each app. I'm nearly-useless at Bash, it hurts my brain bad.