### PR TITLE
Add Headscale support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,21 @@ Set an auth key or oauth client key to the global config:
 dokku config:set --global TS_AUTHKEY=tskey-client-00000000000000000-000000000000000000000000000000000
 ```
 
+&nbsp;
+
+_(Optional)_ Set login server url to the global config:
+
+```sh
+dokku config:set --global TS_LOGIN_SERVER=https://headscale.example.com
+```
+
+_(Optional)_ Set tailscale extra args to the global config:
+
+```sh
+# Example to force re-authentication
+dokku config:set --global TS_EXTRA_ARGS="--force-reauth"
+```
+
 Presently, all apps will be tagged in the tailnet with `dokku`.
 
 ## Usage

--- a/functions
+++ b/functions
@@ -74,6 +74,12 @@ tailscale_attach() {
   local authkey="$(config_get --global TS_AUTHKEY)"
   [[ -z "$authkey" ]] && dokku_log_fail "Set the TS_AUTHKEY with dokku config:set --global"
 
+  local login_arg=""
+  local login_server="$(config_get --global TS_LOGIN_SERVER)"
+  [[ -n "${login_server}" ]] && login_arg="--login-server=${login_server}"
+
+  local ts_extra_args="$(config_get --global TS_EXTRA_ARGS)"
+
   local storage_directory="${DOKKU_LIB_ROOT}/data/tailscale/${APP}"
 
   dokku_log_info1 "starting tailscale container ts-${APP}"
@@ -82,7 +88,7 @@ tailscale_attach() {
     $DOKKU_GLOBAL_RUN_ARGS \
     --name "ts-${APP}" \
     --env TS_AUTHKEY="${authkey}" \
-    --env TS_EXTRA_ARGS="--advertise-tags=tag:dokku" \
+    --env TS_EXTRA_ARGS="--advertise-tags=tag:dokku ${login_arg} ${ts_extra_args}" \
     --env TS_STATE_DIR=/var/lib/tailscale \
     --volume "${storage_directory}":/var/lib/tailscale \
     --volume /dev/net/tun:/dev/net/tun \


### PR DESCRIPTION
Add Headscale support by setting `TS_LOGIN_SERVER` in `--global` config.
Also allow passing extra arguments to docker image with `TS_EXTRA_ARGS`